### PR TITLE
Fixed Guard Rspec Spork stuff, Gemfile cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,14 +4,19 @@ source 'https://rubygems.org'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.5.1'
 # Use sqlite3 as the database for Active Record
-	group :development, :test do
+group :development, :test do
 	gem 'sqlite3'
-	#rspec
+	
 	%w[rspec-core rspec-expectations rspec-mocks rspec-rails rspec-support].each do |lib|
-		gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch=>'master'
-		end
-	#factory girl
+		gem lib
+	end
+	
 	gem "factory_girl_rails", "~> 4.0"
+  gem 'byebug'
+	gem 'guard'
+	gem 'guard-rspec', '4.6.0', require: false
+	gem 'spork-rails'
+	gem 'guard-spork'
 end
 
 # Use SCSS for stylesheets
@@ -41,28 +46,12 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
-group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug'
-end
-
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-
-	# guard
-	gem 'guard'
-	gem 'guard-rspec', require: false
-
-	#spork
-	gem 'spork-rails'
-
-	#guard spork
-	gem 'guard-spork'
-
 end
 
 # postgreSQL for Heroku
@@ -82,5 +71,3 @@ gem 'stripe'
 
 ## Gemfile for Rails 3+
 gem 'will_paginate', '~> 3.0.5'
-
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,50 +1,3 @@
-GIT
-  remote: https://github.com/rspec/rspec-core.git
-  revision: e95067ed9815075ba12126d8d456adbb4dc0def7
-  branch: master
-  specs:
-    rspec-core (3.5.0.pre)
-      rspec-support (= 3.5.0.pre)
-
-GIT
-  remote: https://github.com/rspec/rspec-expectations.git
-  revision: eb5113d77460faca78e9241c91b771b0f9689946
-  branch: master
-  specs:
-    rspec-expectations (3.5.0.pre)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (= 3.5.0.pre)
-
-GIT
-  remote: https://github.com/rspec/rspec-mocks.git
-  revision: a234a3830967d3fe0428a5350aa75bb7e1db375c
-  branch: master
-  specs:
-    rspec-mocks (3.5.0.pre)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (= 3.5.0.pre)
-
-GIT
-  remote: https://github.com/rspec/rspec-rails.git
-  revision: 682a12067eab233c646057f984692e3b70749f32
-  branch: master
-  specs:
-    rspec-rails (3.5.0.pre)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      railties (>= 3.0)
-      rspec-core (= 3.5.0.pre)
-      rspec-expectations (= 3.5.0.pre)
-      rspec-mocks (= 3.5.0.pre)
-      rspec-support (= 3.5.0.pre)
-
-GIT
-  remote: https://github.com/rspec/rspec-support.git
-  revision: ebaf25c0f25f5e23b1cfa89652894f4892c8a4f8
-  branch: master
-  specs:
-    rspec-support (3.5.0.pre)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -133,8 +86,10 @@ GEM
       shellany (~> 0.0)
       thor (>= 0.18.1)
     guard-compat (1.2.1)
-    guard-rspec (1.2.2)
-      guard (>= 1.1)
+    guard-rspec (4.6.0)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
     guard-spork (2.1.0)
       childprocess (>= 0.2.3)
       guard (~> 2.0)
@@ -221,6 +176,27 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-rails (3.4.2)
+      actionpack (>= 3.0, < 4.3)
+      activesupport (>= 3.0, < 4.3)
+      railties (>= 3.0, < 4.3)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
     sass (3.4.21)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -280,18 +256,18 @@ DEPENDENCIES
   devise
   factory_girl_rails (~> 4.0)
   guard
-  guard-rspec
+  guard-rspec (= 4.6.0)
   guard-spork
   jbuilder (~> 2.0)
   jquery-rails
   pg
   rails (= 4.2.5.1)
   rails_12factor
-  rspec-core!
-  rspec-expectations!
-  rspec-mocks!
-  rspec-rails!
-  rspec-support!
+  rspec-core
+  rspec-expectations
+  rspec-mocks
+  rspec-rails
+  rspec-support
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   spork-rails

--- a/Guardfile
+++ b/Guardfile
@@ -15,6 +15,60 @@
 #
 # and, you'll have to watch "config/Guardfile" instead of "Guardfile"
 
+# Note: The cmd option is now required due to the increasing number of ways
+#       rspec may be run, below are examples of the most common uses.
+#  * bundler: 'bundle exec rspec'
+#  * bundler binstubs: 'bin/rspec'
+#  * spring: 'bin/rspec' (This will use spring if running and you have
+#                          installed the spring binstubs per the docs)
+#  * zeus: 'zeus rspec' (requires the server to be started separately)
+#  * 'just' rspec: 'rspec'
+
+guard :rspec, cmd: "bundle exec rspec" do
+  require "guard/rspec/dsl"
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # Feel free to open issues for suggestions and improvements
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files)
+
+  # Ruby files
+  ruby = dsl.ruby
+  dsl.watch_spec_files_for(ruby.lib_files)
+
+  # Rails files
+  rails = dsl.rails(view_extensions: %w(erb haml slim))
+  dsl.watch_spec_files_for(rails.app_files)
+  dsl.watch_spec_files_for(rails.views)
+
+  watch(rails.controllers) do |m|
+    [
+      rspec.spec.("routing/#{m[1]}_routing"),
+      rspec.spec.("controllers/#{m[1]}_controller"),
+      rspec.spec.("acceptance/#{m[1]}")
+    ]
+  end
+
+  # Rails config changes
+  watch(rails.spec_helper)     { rspec.spec_dir }
+  watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
+  watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
+
+  # Capybara features specs
+  watch(rails.view_dirs)     { |m| rspec.spec.("features/#{m[1]}") }
+  watch(rails.layouts)       { |m| rspec.spec.("features/#{m[1]}") }
+
+  # Turnip features and steps
+  watch(%r{^spec/acceptance/(.+)\.feature$})
+  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
+    Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
+  end
+end
+
 guard :spork, :cucumber_env => { 'RAILS_ENV' => 'test' }, :rspec_env => { 'RAILS_ENV' => 'test' } do
   watch('config/application.rb')
   watch('config/environment.rb')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'spork'
+require 'rspec/core'
 #uncomment the following line to use spork with the debugger
 #require 'spork/ext/ruby-debug'
 


### PR DESCRIPTION
Hey Citlas ;D

I spent some time and figured out what was wrong with your Guard/Rspec/Spork stuff. This thread on Stack Overflow describes it:

http://stackoverflow.com/questions/28046509/error-could-not-load-guard-rspec-or-find-class-guardrspec

Basically, it was an incompatibility between the version of `guard-rspec` and the version of `rspec` that you were using.

I got rid of the git branch stuff for the different `rspec` gems in your Gemfile, and cleaned up the Gemfile a little bit while I was in there. Then I ran `bundle`, which downloaded the latest versions of those gems, and updated the `Gemfile.lock`. I also set up your `Guardfile` to look like how it should have looked if `bundle exec guard rspec` hadn't errored out, and I added a line to your `spec_helper.rb` to make the Rspec part work.

You can merge this by pressing the big green merge button. After that, these changes will show up on your Github. From there, do a `git pull` to pull my changes down. After that, run `bundle` to update your gems with the changes I made.

After all that, you should be able to run `bundle exec guard start`, and after you make a change in your files, it will automatically run your tests.

Let me know if you have trouble! ;D
